### PR TITLE
Rebrand to http4s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# natchez-http4s-otel - Opinionated Natchez Http4s Middlewares [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.chrisdavenport/natchez-http4s-otel_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.chrisdavenport/natchez-http4s-otel_2.12) ![Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-Scala-blue.svg)
-
-## [Head on over to the microsite](https://ChristopherDavenport.github.io/natchez-http4s-otel)
+# http4s-otel4s
 
 ## Quick Start
 
-To use natchez-http4s-otel in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
+To use http4s-otel4s in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.chrisdavenport" %% "natchez-http4s-otel" % "<version>"
+  "org.http4s" %% "http4s-otel4s-middleware" % "<version>"
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,11 @@
 import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "0.3" // your current series x.y
+ThisBuild / tlBaseVersion := "0.1" // your current series x.y
 
-ThisBuild / organization := "io.chrisdavenport"
-ThisBuild / organizationName := "Christopher Davenport"
+ThisBuild / organization := "org.http4s"
+ThisBuild / organizationName := "http4s.org"
 ThisBuild / licenses := Seq(License.MIT)
-ThisBuild / developers := List(
-  // your GitHub handle and name
-  tlGitHubDev("christopherdavenport", "Christopher Davenport")
-)
+ThisBuild / developers += tlGitHubDev("rossabaker", "Ross A. Baker")
 
 ThisBuild / tlCiReleaseBranches := Seq("main")
 
@@ -40,14 +37,14 @@ val slf4jV    = "1.7.36"
 
 
 // Projects
-lazy val `natchez-http4s-otel` = tlCrossRootProject
+lazy val `http4s-otel4s-middleware` = tlCrossRootProject
   .aggregate(core, examples)
 
 lazy val core = crossProject(JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("core"))
   .settings(
-    name := "http4s-otel4s",
+    name := "http4s-otel4s-middleware",
 
     libraryDependencies ++= Seq(
       "org.typelevel"               %%% "cats-core"                  % catsV,
@@ -60,12 +57,12 @@ lazy val core = crossProject(JVMPlatform)
       "org.http4s"                  %%% "http4s-client"              % http4sV,
 
       "org.typelevel"               %%% "otel4s-core-trace"          % otel4sV,
-      "org.typelevel"               %%% "otel4s-java"                % otel4sV,
       "org.typelevel"               %%% "cats-mtl"                   % catsMtlV,
 
       "io.opentelemetry"            % "opentelemetry-sdk-testing"    % openTelemetryV   % Test,
       "org.typelevel"               %%% "cats-effect-testkit"        % catsEffectV      % Test,
       "org.typelevel"               %%% "munit-cats-effect"          % munitCatsEffectV % Test,
+      "org.typelevel"               %%% "otel4s-java"                % otel4sV          % Test,
     )
   )
 

--- a/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
@@ -1,4 +1,4 @@
-package io.chrisdavenport.http4sotel4s
+package org.http4s.otel4s.middleware
 
 import cats.Applicative
 import cats.effect.kernel.Outcome
@@ -30,7 +30,7 @@ object ClientMiddleware {
     def includeUrl[F[_]]: Request[F] => Boolean = {(_: Request[F]) => true}
   }
 
-  final class ClientMiddlewareBuilder[F[_]: Tracer: Concurrent] private[ClientMiddleware] (
+  final class ClientMiddlewareBuilder[F[_]: Tracer: Concurrent] private[ClientMiddleware](
     private val reqHeaders: Set[CIString],
     private val respHeaders: Set[CIString],
     private val clientSpanName: Request[F] => String,
@@ -108,7 +108,7 @@ object ClientMiddleware {
 
   val ExtraTagsKey: Key[List[Attribute[_]]] = Key.newKey[SyncIO, List[Attribute[_]]].unsafeRunSync()
 
-  private[http4sotel4s] def request[F[_]](req: Request[F], headers: Set[CIString]): List[Attribute[_]] = {
+  private[middleware] def request[F[_]](req: Request[F], headers: Set[CIString]): List[Attribute[_]] = {
     request(req, headers, Function.const[Boolean, Request[F]](true)(_))
   }
   def request[F[_]](request: Request[F], headers: Set[CIString], includeUrl: Request[F] => Boolean): List[Attribute[_]] = {

--- a/core/src/main/scala/org/http4s/otel4s/middleware/OTHttpTags.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/OTHttpTags.scala
@@ -1,4 +1,4 @@
-package io.chrisdavenport.http4sotel4s
+package org.http4s.otel4s.middleware
 
 import org.http4s._
 import org.typelevel.otel4s.Attribute

--- a/core/src/main/scala/org/http4s/otel4s/middleware/ServerMiddleware.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/ServerMiddleware.scala
@@ -1,4 +1,4 @@
-package io.chrisdavenport.http4sotel4s
+package org.http4s.otel4s.middleware
 
 import cats.data.Kleisli
 import cats.effect.kernel.{MonadCancelThrow, Outcome}
@@ -28,7 +28,7 @@ object ServerMiddleware {
     def doNotTrace: RequestPrelude => Boolean = {(_: RequestPrelude) => false}
   }
 
-  final class ServerMiddlewareBuilder[F[_]: Tracer: MonadCancelThrow] private[ServerMiddleware] (
+  final class ServerMiddlewareBuilder[F[_]: Tracer: MonadCancelThrow] private[ServerMiddleware](
     isKernelHeader: CIString => Boolean,
     reqHeaders: Set[CIString],
     respHeaders: Set[CIString],
@@ -104,7 +104,7 @@ object ServerMiddleware {
       buildTracedF(f)
   }
 
-  private[http4sotel4s] def request[F[_]](req: Request[F], headers: Set[CIString], routeClassifier: Request[F] => Option[String]): List[Attribute[_]] = {
+  private[middleware] def request[F[_]](req: Request[F], headers: Set[CIString], routeClassifier: Request[F] => Option[String]): List[Attribute[_]] = {
     request(req, headers, routeClassifier, Function.const[Boolean, Request[F]](true))
   }
 

--- a/core/src/main/scala/org/http4s/otel4s/middleware/helpers.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/helpers.scala
@@ -1,9 +1,9 @@
-package io.chrisdavenport.http4sotel4s
+package org.http4s.otel4s.middleware
 
 import java.io.{OutputStream, FilterOutputStream, ByteArrayOutputStream, PrintStream}
 import scala.util.Using
 
-private[http4sotel4s] object helpers {
+private[middleware] object helpers {
   def printStackTrace(e: Throwable): String = {
     val baos = new ByteArrayOutputStream
     Using.resource(new AnsiFilterStream(baos)) { fs =>

--- a/core/src/main/scala/org/http4s/otel4s/middleware/package.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/package.scala
@@ -1,10 +1,10 @@
-package io.chrisdavenport
+package org.http4s.otel4s
 
 import org.http4s.{Header, Headers}
 import org.typelevel.ci.CIString
 import org.typelevel.otel4s.context.propagation.{TextMapGetter, TextMapUpdater}
 
-package object http4sotel4s {
+package object middleware {
   implicit val headersTMU: TextMapUpdater[Headers] =
     (carrier: Headers, key: String, value: String) => carrier.put(Header.Raw(CIString(key), value))
   implicit val headersTMG: TextMapGetter[Headers] =

--- a/core/src/test/scala/org/http4s/otel4s/middleware/ClientMiddlewareTests.scala
+++ b/core/src/test/scala/org/http4s/otel4s/middleware/ClientMiddlewareTests.scala
@@ -1,4 +1,4 @@
-package io.chrisdavenport.http4sotel4s
+package org.http4s.otel4s.middleware
 
 import munit.CatsEffectSuite
 import cats.effect.{IO, IOLocal}

--- a/examples/src/main/scala/example/Http4sExample.scala
+++ b/examples/src/main/scala/example/Http4sExample.scala
@@ -6,10 +6,10 @@ import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.server.Server
 import org.http4s.implicits._
-import io.chrisdavenport.http4sotel4s._
 import com.comcast.ip4s._
 import fs2.io.net.Network
 import io.opentelemetry.api.GlobalOpenTelemetry
+import org.http4s.otel4s.middleware.{ClientMiddleware, ServerMiddleware}
 import org.typelevel.otel4s.Otel4s
 import org.typelevel.otel4s.java.OtelJava
 import org.typelevel.otel4s.java.instances._


### PR DESCRIPTION
Still required after this:

- Updating the build to use the http4s sbt plugin
- Updating the project structure so that tests are a separate, JVM-only project, so that the library can be published cross-platform